### PR TITLE
typo: gpg -> pgp

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,15 +54,15 @@
                 </div>
               </div>
               <div class="form-group row">
-                <label for="gpg" class="col-sm-3 col-form-label">GPG Fingerprint </label>
+                <label for="pgp" class="col-sm-3 col-form-label">PGP Fingerprint </label>
                 <div class="col-sm-9">
                   <div class="input-group mb-2">
                     <div class="input-group-prepend">
                       <div class="input-group-text">0x</div>
                     </div>
-                    <input type="text" class="form-control" id="gpg" name="gpg" aria-describedby="gpg-help" maxlength="40">
+                    <input type="text" class="form-control" id="pgp" name="pgp" aria-describedby="pgp-help" maxlength="40">
                   </div>
-                  <small id="gpg-help" class="form-text text-muted">PGP key fingerprint (long form) without spaces. This key should be available on <a href="https://keys.openpgp.org">keys.openpgp.org</a></small>
+                  <small id="pgp-help" class="form-text text-muted">PGP key fingerprint (long form) without spaces. This key should be available on <a href="https://keys.openpgp.org">keys.openpgp.org</a></small>
                 </div>
               </div>
               <div class="form-group row">


### PR DESCRIPTION
The spec uses "pgp"
https://nusenu.github.io/ContactInfo-Information-Sharing-Specification/#pgp